### PR TITLE
Configure <Link /> through Route<P>

### DIFF
--- a/example/basic/app/HelloPage.tsx
+++ b/example/basic/app/HelloPage.tsx
@@ -10,7 +10,9 @@ export default function HelloPage(props: HelloPageProps) {
   return (
     <div>
       <div>HELLO {props.name}</div>
-      <ASAP.Link href={ASAP.href(routes.index)}>Back to /</ASAP.Link>
+      <ASAP.Link route={routes.index} params={{}}>
+        Back to /
+      </ASAP.Link>
     </div>
   );
 }

--- a/example/basic/app/IndexPage.tsx
+++ b/example/basic/app/IndexPage.tsx
@@ -8,7 +8,7 @@ export default function IndexPage(_props: IndexPageProps) {
   return (
     <div>
       <div>Welcome!</div>
-      <ASAP.Link href={ASAP.href(routes.hello, { name: "World" })}>
+      <ASAP.Link route={routes.hello} params={{ name: "World" }}>
         Say hello!
       </ASAP.Link>
     </div>

--- a/src/Routing.ts
+++ b/src/Routing.ts
@@ -29,7 +29,7 @@ export type Route<Path extends string> = {
  */
 export function href<P extends string>(
   route: Route<P>,
-  params: RouteParams<P> = {}
+  params: RouteParams<P>
 ): string {
   return regexparam.inject(route.path, params as any);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,27 +24,33 @@ export function boot(routes: Router.Routes) {
   });
 }
 
-export type LinkProps = React.HTMLProps<HTMLAnchorElement>;
+export type LinkProps<P extends string> = {
+  route: Router.Route<P>;
+  params: Router.RouteParams<P>;
+} & Omit<React.HTMLProps<HTMLAnchorElement>, "href">;
 
 /**
  * <Link /> component render an <a /> element which performs client side
  * naviation on press.
  */
-export function Link(props: LinkProps) {
-  let router = Router.useRouter();
-  let onClick: React.MouseEventHandler = (ev) => {
-    if (props.href == null) return;
-    if (
-      props.href.startsWith("http:") ||
-      props.href.startsWith("https:") ||
-      props.href.startsWith("mailto:")
-    )
-      return;
-    ev.preventDefault();
-    router.navigate(props.href);
-  };
-  return <a {...props} onClick={onClick} />;
-}
+export let Link = React.forwardRef(
+  <P extends string>(
+    { route, params, ...props }: LinkProps<P>,
+    ref: React.Ref<HTMLAnchorElement>
+  ) => {
+    let router = Router.useRouter();
+    let href = Routing.href(route, params);
+    let onClick: React.MouseEventHandler<HTMLAnchorElement> = React.useCallback(
+      (ev) => {
+        ev.preventDefault();
+        router.navigate(href);
+        props.onClick?.(ev);
+      },
+      [href]
+    );
+    return <a {...props} ref={ref} href={href} onClick={onClick} />;
+  }
+);
 
 type AppProps = {
   routes: Router.Routes;


### PR DESCRIPTION
Instead of passing `href` to `<Link />` component we allow to pass `route` and route params through `props`. The `href` is then generated through `Routing.href()` function.

The motivation is that the <Link /> component should be used for intra-app navigation only and therefore there's no need to expose raw `href` prop.

In commit route params are spread through `<Link />` props:

      <Link route={userProfile} userId="1" />

The GOOD is that it's very concise but the BAD is that it's clashing with `children`, `htmlProps` and `route` props. Also passing HTML props via `htmlProps` become very verbose:

      <Link
        route={userProfile}
        userId="1"
        htmlProps={{className: 'some'}}
        />

We can allow passing some common props like `className`, `style` directly as well? This will lead to more conflicts with possible param names.

The ALTERNATIVE is:

      <Link route={userProfile} params={{userId: "1"}} />

But this one is very verbose. Though there are no conflicts possible and passing HTML props becomes as easy as:

      <Link
        route={userProfile}
        params={{userId: "1"}}
        className="some"
        />
